### PR TITLE
Scope `on()` callbacks to `View.el` only. r=justindarc

### DIFF
--- a/dist/mvc.js
+++ b/dist/mvc.js
@@ -1394,7 +1394,10 @@ define(["exports"], function (exports) {
       return this.el.querySelectorAll(selector);
     };
 
-    View.prototype.on = function (type, selector, handler) {
+    View.prototype.on = function (type, selector, handler, scope) {
+      var controller = this.controller;
+      scope = scope || this.el;
+
       if (!events[type]) {
         events[type] = [];
         window.addEventListener(type, delegateHandler, true);
@@ -1403,7 +1406,8 @@ define(["exports"], function (exports) {
       events[type].push({
         selector: selector,
         handler: handler,
-        controller: this.controller
+        controller: controller,
+        scope: scope
       });
     };
 
@@ -1442,7 +1446,7 @@ define(["exports"], function (exports) {
     var target = event.target;
 
     events[event.type].forEach(function (delegate) {
-      if (target.matches(delegate.selector)) {
+      if (delegate.scope.contains(target) && target.matches(delegate.selector)) {
         if (delegate.handler) {
           delegate.handler.call(target, event);
         } else {

--- a/mvc.js
+++ b/mvc.js
@@ -135,7 +135,10 @@ export class View {
    *
    *
    */
-  on(type, selector, handler) {
+  on(type, selector, handler, scope) {
+    var controller = this.controller;
+    scope = scope || this.el;
+
     if (!events[type]) {
       events[type] = [];
       window.addEventListener(type, delegateHandler, true);
@@ -144,7 +147,8 @@ export class View {
     events[type].push({
       selector: selector,
       handler: handler,
-      controller: this.controller
+      controller: controller,
+      scope: scope
     });
   }
 
@@ -183,7 +187,7 @@ function delegateHandler(event) {
   var target = event.target;
 
   events[event.type].forEach((delegate) => {
-    if (target.matches(delegate.selector)) {
+    if (delegate.scope.contains(target) && target.matches(delegate.selector)) {
       if (delegate.handler) {
         delegate.handler.call(target, event);
       } else {


### PR DESCRIPTION
@justindarc, r? Please merge if you r+.

The ```on()``` callbacks get a bit ugly when we have multiple ```View```s registering the same callback. They trip each other since the main callback is scoped to ```window```. This adds scoping for each callback to the `this.el` element, where `this` is the ```View```.